### PR TITLE
Add android namespace

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
+        xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-mobile-ocr"
         version="3.1.1">
 


### PR DESCRIPTION
Some parsers require the namespace for `android:` prefixed tags.