### PR TITLE
android - compatibility with android 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-mobile-ocr",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/NeutrinosPlatform/cordova-plugin-mobile-ocr"

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,8 +29,10 @@
     </config-file> 
 
     <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
             <meta-data
             android:name="com.google.android.gms.vision.DEPENDENCIES"
             android:value="ocr"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-mobile-ocr"
-        version="3.1.2">
+        version="3.1.3">
 
   <name>Textocr</name>
 
@@ -29,10 +29,6 @@
     </config-file> 
 
     <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
             <meta-data
             android:name="com.google.android.gms.vision.DEPENDENCIES"
             android:value="ocr"/>


### PR DESCRIPTION
With  android version 13 the permitions required to access images from WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE, to READ_MEDIA_IMAGES and READ_MEDIA_VIDEO.

After going through the code, I see that these permitions aren't even required since the process of accessing the images has to be done through another plugin like (`cordova-plugin-camera`) that have to include this process of requesting permition. 

This pull request removes these permition in orther to make it compatible with the latest versions of the plugins that handle to process of accessing the image.