### PR TITLE
refactor(ios): switches framework tag to podspec config for cordova-ios ^7.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,16 @@
 <header-file src="src/ios/Textocr.h" target-dir="OcrPlugin"/>
 <source-file src="src/ios/Textocr.m" target-dir="OcrPlugin"/>
 
-<framework src="GoogleMobileVision/TextDetector" type="podspec" spec="~> 1.3.2"/> 
+<podspec>
+  <config>
+    <source url="https://github.com/CocoaPods/Specs.git"/>
+  </config>
+  <pods use-frameworks="true">
+    <pod name="GoogleMobileVision/TextDetector" spec="~> 1.3.2" />
+  </pods>
+</podspec>
+
+<!-- <framework src="GoogleMobileVision/TextDetector" type="podspec" spec="~> 1.3.2"/>  -->
 <!--<framework src="GTMSessionFetcher" type="podspec" spec="~> 1.1.15"/>-->
 <!--<framework src="Protobuf" type="podspec" spec="~> 3.6.0"/>-->
 <!--<framework src="GoogleToolboxForMac" type="podspec" spec="~> 2.1.4"/>-->


### PR DESCRIPTION
I changed the framework def locally and it seems to work

https://github.com/NeutrinosPlatform/cordova-plugin-mobile-ocr/issues/49